### PR TITLE
Project Setup: Local environment

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -64,6 +64,24 @@
                             "extractLicenses": false,
                             "sourceMap": true,
                             "namedChunks": true
+                        },
+                        "local": {
+                            "buildOptimizer": false,
+                            "optimization": false,
+                            "vendorChunk": true,
+                            "extractLicenses": false,
+                            "namedChunks": true,
+                            "fileReplacements": [
+                                {
+                                    "replace": "src/environments/environment.ts",
+                                    "with": "src/environments/environment.local.ts"
+                                }
+                            ],
+                            "sourceMap": {
+                                "scripts": true,
+                                "styles": true,
+                                "vendor": false
+                            }
                         }
                     },
                     "defaultConfiguration": "production"
@@ -76,6 +94,9 @@
                         },
                         "development": {
                             "browserTarget": "platformer:build:development"
+                        },
+                        "local": {
+                            "browserTarget": "platformer:build:local"
                         }
                     },
                     "defaultConfiguration": "development"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "scripts": {
         "ng": "ng",
         "start": "ng serve",
+        "start:local": "ng serve --configuration=local --disableHostCheck=true",
         "build": "ng build",
         "watch": "ng build --watch --configuration development",
         "test": "ng test",

--- a/src/environments/environment.local.ts
+++ b/src/environments/environment.local.ts
@@ -1,0 +1,4 @@
+export const environment = {
+    production: true,
+    showDebug: true, // Set to true to make Phaser show debug info during development.
+};

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
     production: true,
+    showDebug: false,
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,6 +4,7 @@
 
 export const environment = {
     production: false,
+    showDebug: false,
 };
 
 /*


### PR DESCRIPTION
The default project has a `development` environment, but I like to setup a `local` one with some specific settings I prefer. The important thing here is adding a property to the environment that will put Phaser into debug when running the project locally.

with these changes, a local dev server can be started with `npm run start:local` which will make the project available at `localhost:4200`