### PR TITLE
UI: Pass service to Phaser

### DIFF
--- a/src/app/components/game/game.component.ts
+++ b/src/app/components/game/game.component.ts
@@ -1,6 +1,7 @@
 import { Component, AfterViewInit } from '@angular/core';
 import { environment } from '../../../environments/environment';
 import { MainGame } from '../../game-canvas/main-game';
+import { GameService } from '../../shared/services/game.service';
 
 @Component({
     selector: 'app-game',
@@ -10,7 +11,7 @@ import { MainGame } from '../../game-canvas/main-game';
 export class GameComponent implements AfterViewInit {
     canvasId: string = 'game-canvas';
     game: MainGame;
-    constructor() {}
+    constructor(private gameService: GameService) {}
     ngAfterViewInit(): void {
         const gameConfig: Phaser.Types.Core.GameConfig = {
             type: Phaser.AUTO,
@@ -29,6 +30,6 @@ export class GameComponent implements AfterViewInit {
                 },
             },
         };
-        this.game = new MainGame(gameConfig);
+        this.game = new MainGame(gameConfig, this.gameService);
     }
 }

--- a/src/app/game-canvas/main-game.ts
+++ b/src/app/game-canvas/main-game.ts
@@ -1,12 +1,19 @@
 import Phaser from 'phaser';
 import { SceneNames } from '../shared/constants/scene-names';
+import { PlatformConfig } from '../shared/interfaces/platform-config';
+import { GameService } from '../shared/services/game.service';
 import { BootScene } from './scenes/boot-scene';
 import { GameScene } from './scenes/game-scene';
 import { LoadScene } from './scenes/load-scene';
 
 export class MainGame extends Phaser.Game {
-    constructor(gameConfig: Phaser.Types.Core.GameConfig) {
+    constructor(gameConfig: Phaser.Types.Core.GameConfig, gameService: GameService) {
         super(gameConfig);
+
+        // The following bit of hackery is letting typescript know that we're redefining the type of an inheritted property.
+        // This needs to be assigned after the super() constructor has been called.
+        // We can't just pass in a PlatformConfig to this class's constructor.
+        (this.config as unknown as PlatformConfig).gameService = gameService;
 
         this.scene.add(SceneNames.BOOT, BootScene);
         this.scene.add(SceneNames.LOAD, LoadScene);

--- a/src/app/shared/interfaces/platform-config.ts
+++ b/src/app/shared/interfaces/platform-config.ts
@@ -1,0 +1,6 @@
+import Phaser from 'phaser';
+import { GameService } from '../services/game.service';
+
+export interface PlatformConfig extends Phaser.Types.Core.GameConfig {
+    gameService: GameService;
+}


### PR DESCRIPTION
Angular uses dependency injection to pass services around to different components. This insures that all components are using the same instance of every service.

In order to give Phaser access to Angular's services, we do the following:
1. Create an interface that extends the standard game config type.
2. Pass the service instance into the main game class
3. set the service on the games config object (we use the new interface to allow this).
